### PR TITLE
chore(frontend): enforce Node.js 20 runtime

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+    "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",


### PR DESCRIPTION
Enforce Node.js 20 runtime for the frontend build to ensure compatibility with Vercel’s deployment environment.