### PR TITLE
chore: stop tracking frontend/.env.local (use Vercel envs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ EOF
 # envs (global)
 **/.env
 **/.env.*
+frontend/.env.local


### PR DESCRIPTION
chore: stop tracking frontend/.env.local (use Vercel envs)